### PR TITLE
Normalize whitespace in return type extraction

### DIFF
--- a/src/extract-return-type.ts
+++ b/src/extract-return-type.ts
@@ -12,7 +12,11 @@ export function extractReturnType(
 ): string | null {
 	if (node.returnType?.typeAnnotation) {
 		const typeNode = node.returnType.typeAnnotation;
-		return source.slice(typeNode.start, typeNode.end).trim();
+		return source.slice(typeNode.start, typeNode.end)
+			.trim()
+			.replace(/\n/g, ' ')
+			.replace(/\t/g, '')
+			.replace(/\s+/g, ' ');
 	}
 	return null;
 }


### PR DESCRIPTION
Replace newlines with spaces, remove tabs, and collapse multiple spaces into single spaces when extracting return types to ensure consistent formatting for multi-line type definitions.

🤖 Generated with [Claude Code](https://claude.ai/code)