### PR TITLE
Add JSON output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,37 @@ path/to/components/Button.tsx	8	Button
 path/to/components/Button.tsx	32	IconButton
 ```
 
+**`json`**  
+Displays results in JSON format, suitable for processing with tools like `jq`. Each file is represented as an object containing its path and an array of functions.
+
+```json
+[
+  {
+    "path": "path/to/auth/login.ts",
+    "functions": [
+      {"line": 12, "name": "validateCredentials", "returnType": "boolean"},
+      {"line": 28, "name": "generateToken", "returnType": "string"},
+      {"line": 45, "name": "handleLoginRequest", "returnType": "Promise<void>"}
+    ]
+  },
+  {
+    "path": "path/to/components/Button.tsx",
+    "functions": [
+      {"line": 8, "name": "Button", "returnType": "JSX.Element"},
+      {"line": 32, "name": "IconButton", "returnType": "JSX.Element"}
+    ]
+  },
+  {
+    "path": "path/to/utils/string.ts",
+    "functions": [
+      {"line": 5, "name": "capitalize", "returnType": "string"},
+      {"line": 11, "name": "truncate", "returnType": "string"},
+      {"line": 23, "name": "sanitizeInput", "returnType": "string"}
+    ]
+  }
+]
+```
+
 #### `--absolute`
 Displays absolute file paths instead of relative paths from the target directory. When not specified, relative paths are displayed.
 

--- a/src/display-function-as-json.ts
+++ b/src/display-function-as-json.ts
@@ -1,0 +1,26 @@
+import { relative } from "node:path";
+
+import type { extractAllFunctions } from "./extract-all-functions";
+
+export function displayFunctionAsJson(
+	targetDir: string,
+	results: Awaited<ReturnType<typeof extractAllFunctions>>,
+	useAbsolutePaths: boolean,
+): void {
+	const output = results.map((result) => {
+		const path = useAbsolutePaths
+			? result.filePath
+			: relative(targetDir, result.filePath);
+
+		return {
+			path,
+			functions: result.functions.map((func) => ({
+				line: func.line,
+				name: func.name,
+				returnType: func.returnType,
+			})),
+		};
+	});
+
+	console.log(JSON.stringify(output));
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,9 @@
 import { resolve } from "node:path";
 import arg from "arg";
+
 import packageJson from "../package.json";
 import { displayFunctionAsGrouped } from "./display-function-as-grouped";
+import { displayFunctionAsJson } from "./display-function-as-json";
 import { displayFunctionAsList } from "./display-function-as-list";
 import { displayFunctionAsTsv } from "./display-function-as-tsv";
 import { displayHeader } from "./display-header";
@@ -9,6 +11,13 @@ import { displayLegend } from "./display-legend";
 import { displaySummary } from "./display-summary";
 import { extractAllFunctions } from "./extract-all-functions";
 import { PreconditionError } from "./precondition-error";
+
+const formatProgressMap: Record<string, boolean> = {
+	grouped: true,
+	list: true,
+	tsv: false,
+	json: false,
+};
 
 export async function main(): Promise<void> {
 	const args = arg({
@@ -28,7 +37,7 @@ export async function main(): Promise<void> {
 	}
 	const targetDir = resolve(process.env.INIT_CWD || ".", targetPath);
 	const formatType = args["--format"] || "grouped";
-	const showProgress = formatType !== "tsv";
+	const showProgress = formatProgressMap[formatType] ?? false;
 	const useAbsolutePaths = args["--absolute"] || false;
 
 	const startTime = Date.now();
@@ -64,6 +73,11 @@ export async function main(): Promise<void> {
 
 	if (formatType === "tsv") {
 		displayFunctionAsTsv(targetDir, results, useAbsolutePaths);
+		return;
+	}
+
+	if (formatType === "json") {
+		displayFunctionAsJson(targetDir, results, useAbsolutePaths);
 		return;
 	}
 


### PR DESCRIPTION
Introduced a new JSON output format option (--format json) that structures the output as an array of objects, where each object contains a file path and its associated functions. Each function includes line number, name, and return type. Also refactored the progress display logic to use a format-to-boolean map for better maintainability.

🤖 Generated with [Claude Code](https://claude.ai/code)