### PR TITLE
Add streaming JSON output to handle large datasets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"arg": "~5.0.2",
 				"glob": "~11.0.0",
+				"json-stream-stringify": "^3.1.6",
 				"oxc-parser": "~0.75.1",
 				"oxc-walker": "~0.3.0",
 				"yoctocolors": "~2.1.1"
@@ -1698,6 +1699,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/json-stream-stringify": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz",
+			"integrity": "sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=7.10.1"
 			}
 		},
 		"node_modules/lilconfig": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	"dependencies": {
 		"arg": "~5.0.2",
 		"glob": "~11.0.0",
+		"json-stream-stringify": "^3.1.6",
 		"oxc-parser": "~0.75.1",
 		"oxc-walker": "~0.3.0",
 		"yoctocolors": "~2.1.1"

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,7 @@ export async function main(): Promise<void> {
 	}
 
 	if (formatType === "json") {
-		displayFunctionAsJson(targetDir, results, useAbsolutePaths);
+		await displayFunctionAsJson(targetDir, results, useAbsolutePaths);
 		return;
 	}
 


### PR DESCRIPTION
Replace JSON.stringify with json-stream-stringify library to prevent memory issues when processing large codebases. The streaming approach writes JSON data progressively to stdout instead of building the entire string in memory.

🤖 Generated with [Claude Code](https://claude.ai/code)